### PR TITLE
Fix dependency link for core-icons

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "polymer": "Polymer/polymer#master",
         "core-icon": "Polymer/core-icon#master",
-        "core-icons": "Polymer/core-icon#master",
+        "core-icons": "Polymer/core-icons#master",
         "core-item": "Polymer/core-item#master",
         "core-menu": "Polymer/core-menu#master",
         "core-overlay": "Polymer/core-overlay"


### PR DESCRIPTION
The `core-icons` dependency was pointing to the `core-icon` repo (notice the missing trailing 's') instead of the `core-icons` repo.
